### PR TITLE
Zip file created outside container directory fixed

### DIFF
--- a/src/handlers/filesystem/fs.ts
+++ b/src/handlers/filesystem/fs.ts
@@ -469,7 +469,7 @@ async rename(id: string, oldPath: string, newPath: string) {
                 }));
 
             const firstFileDir = path.dirname(files[0].fullPath);
-            const zipPath = path.join(firstFileDir, `${zipname}.zip`);
+            const zipPath = path.join(baseDirectory, `${zipname}.zip`);
 
             await fs.mkdir(path.dirname(zipPath), { recursive: true });
 

--- a/src/handlers/filesystem/fs.ts
+++ b/src/handlers/filesystem/fs.ts
@@ -468,7 +468,10 @@ async rename(id: string, oldPath: string, newPath: string) {
                     fullPath: path.join(baseDirectory, file.replace(/[\[\]"']/g, '').trim())
                 }));
 
-            const firstFileDir = path.dirname(files[0].fullPath);
+           /* const firstFileDir = path.dirname(files[0].fullPath); 
+            const zipPath = path.join(firstFileDir, `${zipname}.zip`);
+            these are unused kept commented for future reference on changes
+            */
             const zipPath = path.join(baseDirectory, `${zipname}.zip`);
 
             await fs.mkdir(path.dirname(zipPath), { recursive: true });


### PR DESCRIPTION
## Problem

The `/fs/zip` endpoint creates zip files outside the container's directory, making them inaccessible via the filesystem API.

### Current Behavior (Broken)

When creating a backup for server `ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb`:

```
ℹ  INFO  Creating zip on remote node: backup_1759387160906.zip
ℹ  INFO  Zip created at system path: /etc/daemon/volumes/backup_1759387160906.zip.zip
ℹ  INFO  Downloading zip from node: /etc/daemon/volumes/backup_1759387160906.zip.zip
 ERROR  Error downloading zip from node: Request failed with status code 500
```

**Issue:** The zip is created at `/etc/daemon/volumes/backup_xxx.zip` instead of `/etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/backup_xxx.zip`

### Expected Behavior (Fixed)

```
ℹ  INFO  Creating zip on remote node: backup_1759387160906.zip
ℹ  INFO  Zip created at system path: /etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/backup_1759387160906.zip.zip
ℹ  INFO  Downloading zip from node: /backup_1759387160906.zip.zip
✓  SUCCESS  Downloaded zip to: /tmp/parachute_xxx.zip
```

### Why This Breaks

1. The zip is created **outside** the container directory
2. The filesystem API's `sanitizePath` function blocks access to paths outside `/etc/daemon/volumes/{UUID}/`
3. Any attempt to download or delete the zip results in a 500 error
4. Zip files accumulate in `/etc/daemon/volumes/` and cannot be cleaned up

## Root Cause

**File:** `src/handlers/filesystem/fs.ts`  
**Lines:** 409-410

```typescript
const firstFileDir = path.dirname(files[0].fullPath);
const zipPath = path.join(firstFileDir, `${zipname}.zip`);
```

When zipping the container root (`/`):
- `files[0].fullPath` = `/etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/`
- `path.dirname()` returns `/etc/daemon/volumes/` (goes up one directory)
- Zip created at: `/etc/daemon/volumes/backup_xxx.zip` ❌

## Solution

Always create zips in the container's base directory:

```typescript
const zipPath = path.join(baseDirectory, `${zipname}.zip`);
```

This ensures:
- `baseDirectory` = `/etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/`
- Zip created at: `/etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/backup_xxx.zip` ✅

## Changes

```diff
async zip(id: string, filePaths: string[] | string, zipname: string): Promise<string> {
    try {
        const baseDirectory = path.resolve(`volumes/${id}`);

        const files = (Array.isArray(filePaths) ? filePaths : [filePaths])
            .flatMap(file =>
                typeof file === 'string'
                    ? file.split(',').map(f => f.trim())
                    : file
            )
            .map(file => ({
                cleanPath: file.replace(/[\[\]"']/g, '').trim(),
                fullPath: path.join(baseDirectory, file.replace(/[\[\]"']/g, '').trim())
            }));

-       const firstFileDir = path.dirname(files[0].fullPath);
-       const zipPath = path.join(firstFileDir, `${zipname}.zip`);
+       const zipPath = path.join(baseDirectory, `${zipname}.zip`);

        await fs.mkdir(path.dirname(zipPath), { recursive: true });
        // ... rest of function
    }
}
```

## Testing

After applying this fix:

1. **Create a backup:**
   ```bash
   curl -X POST http://node:port/fs/zip \
     -u Airlink:key \
     -d '{"id":"ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb","path":["/"],"zipname":"test"}'
   ```

2. **Verify correct path returned:**
   ```json
   {
     "zipPath": "/etc/daemon/volumes/ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb/test.zip"
   }
   ```

3. **Download should succeed:**
   ```bash
   curl -X GET "http://node:port/fs/download?id=ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb&path=/test.zip" \
     -u Airlink:key \
     --output test.zip
   ```

4. **Delete should succeed:**
   ```bash
   curl -X DELETE http://node:port/fs/rm \
     -u Airlink:key \
     -d '{"id":"ad5d8ec8-83e4-4c3b-92b7-1a184c9005fb","path":"/test.zip"}'
   ```

## Impact

**Fixes:**
- Backup systems that rely on `/fs/zip` (e.g., Parachute addon)
- Prevents orphaned zip files in `/etc/daemon/volumes/`
- Maintains security by keeping all files within container boundaries

**Breaking Changes:** None - this only fixes the broken behavior

## Related

Resolves issues with backup creation, Google Drive uploads, and file cleanup operations that depend on the zip endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP archives are now created in the project’s base (volume) directory instead of the directory of the first input file.
  * Ensures a consistent, predictable archive location for scripts and workflows that expect archives at the project root.
  * No changes to archive contents or creation behavior—only the output path was adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->