### PR TITLE
Update instances.ts

### DIFF
--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -201,12 +201,12 @@ router.post("/container/install", async (req: Request, res: Response) => {
 
 router.get("/container/status/:id", (req: Request, res: Response) => {
   const rawId = req.params.id;
-const id = Array.isArray(rawId) ? rawId[0] : rawId;
+  const id = Array.isArray(rawId) ? rawId[0] : rawId;
 
-if (!id) {
-  res.status(400).json({ error: "Container ID is required." });
-  return;
-}
+  if (!id) {
+    res.status(400).json({ error: "Container ID is required." });
+    return;
+  }
 
 const state = getServerState(id);
   

--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -200,15 +200,16 @@ router.post("/container/install", async (req: Request, res: Response) => {
 });
 
 router.get("/container/status/:id", (req: Request, res: Response) => {
-  const { id } = req.params;
+  const rawId = req.params.id;
+const id = Array.isArray(rawId) ? rawId[0] : rawId;
 
-  if (!id) {
-    res.status(400).json({ error: "Container ID is required." });
-    return;
-  }
+if (!id) {
+  res.status(400).json({ error: "Container ID is required." });
+  return;
+}
 
-  const state = getServerState(id);
-
+const state = getServerState(id);
+  
   if (!state) {
     res
       .status(404)


### PR DESCRIPTION
## Fix: Normalize Express route param type before calling getServerState

### Problem
TypeScript was throwing the following error in `src/routes/instances.ts`:

> Argument of type `string | string[]` is not assignable to parameter of type `string`.

Express route parameters are typed as `string | string[]`, but `getServerState()` expects a strict `string`.  
Passing `req.params.id` directly caused a type mismatch at compile time.

### Solution
The route handler now normalizes the `id` parameter before using it:

- If `id` is an array, the first value is used.
- If `id` is already a string, it is used directly.
- If `id` is missing or empty, the request returns `400 Bad Request`.

This guarantees that `getServerState()` always receives a valid `string`.

### Code Change
```ts
const rawId = req.params.id;
const id = Array.isArray(rawId) ? rawId[0] : rawId;

if (!id) {
  res.status(400).json({ error: "Container ID is required." });
  return;
}

const state = getServerState(id);

```
# NOTE
who fucked up the repos so bad why is it failing bro get you shit together
oh and for some reason express dosen't install on first try i have to manually do
```
 "npm install express" 
```
to actually install it



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the container status endpoint to reliably handle id parameters provided in different formats (e.g., single value or array), improving stability and correctness when retrieving container information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->