### PR TITLE
Security: make filesystem jail operations race-safe

### DIFF
--- a/docs/security-fix-guides/issue-15-filesystem-jail.md
+++ b/docs/security-fix-guides/issue-15-filesystem-jail.md
@@ -1,0 +1,29 @@
+# Issue #15 implementation guide — filesystem jail race safety
+
+Reference guide for fixing #15. This branch intentionally documents the target design instead of pretending a speculative security patch is production-ready.
+
+## Current code to replace
+
+- `src/security/pathJail.ts`: `jailPath`, `jailRename`, `secureUnlink`
+- `src/security/secureOpen.ts`: `secureOpenRead`, `secureOpenWrite`
+
+The current pattern is effectively `validate/realpath -> ordinary pathname syscall`. `secureUnlink` is especially clear: secure-open + `fstat` + close + `unlink(path)`. `jailRename` validates both names and then calls ordinary `rename`.
+
+## Target design
+
+1. Treat the jail root as a directory object, not a string prefix.
+2. Prefer directory-FD-relative operations.
+3. On Linux, use `openat2` with the containment constraints required by the threat model, including `RESOLVE_BENEATH` and `RESOLVE_NO_SYMLINKS` where appropriate.
+4. Implement remove/rename without closing the security anchor and then trusting a mutable absolute path.
+5. Give non-Linux fallback code explicit guarantees and limitations.
+6. Make secure APIs accept jail-relative paths so callers cannot pass a pre-resolved path around the boundary.
+
+## Regression matrix
+
+Test existing/missing files and parents, final/intermediate symlinks, traversal, absolute paths, null bytes, long paths, hard links, and concurrent replacement.
+
+Race tests should repeatedly swap an ancestor or target with a symlink while the protected operation runs and assert an outside sentinel is never read, written, renamed, or deleted.
+
+## Acceptance criteria
+
+No security-sensitive operation relies on `realpath()` or a string-prefix check as the final containment guarantee. Linux and fallback paths have explicit tests and documented guarantees.

--- a/docs/security-fix-guides/issue-15-pr-note.md
+++ b/docs/security-fix-guides/issue-15-pr-note.md
@@ -1,0 +1,3 @@
+# Example PR guide
+
+See issue #15 for required implementation and tests. This branch exists as a non-mergeable reference scaffold.


### PR DESCRIPTION
## Summary
The filesystem security layer currently separates path validation from the filesystem operation that ultimately uses the path. Several functions are described as TOCTOU-safe, but the actual implementation still performs ordinary pathname syscalls after validation.

## Code paths
- `src/security/pathJail.ts`: `jailPath()`, `jailRename()`, `secureUnlink()`
- `src/security/secureOpen.ts`: `secureOpenRead()`, `secureOpenWrite()`

`secureUnlink()` effectively does `secure open -> fstat -> close -> unlink(path)`. `jailRename()` validates source/destination and later invokes ordinary `rename()`. `secureOpen*()` uses `AT_FDCWD` and `RESOLVE_NO_SYMLINKS`, while the containment proof comes from a separate pathname/realpath check.

## Why the current model is insufficient
`RESOLVE_NO_SYMLINKS` prevents symlink traversal during that particular open, but it does not turn a previous `realpath()` check into an atomic containment guarantee. Likewise, `O_NOFOLLOW` is not equivalent for intermediate components. A directory or target can be replaced between validation and the later operation.

This is a systemic issue because the same path helpers are intended to protect volumes, backups, downloads, uploads, and other daemon-managed storage.

## Proposed implementation
1. Open the jail root once and retain a directory FD for the operation.
2. Use descriptor-relative operations wherever possible.
3. On Linux, use `openat2` with an explicit `RESOLVE_BENEATH` + `RESOLVE_NO_SYMLINKS` policy where appropriate.
4. Implement unlink/rmdir/rename using race-resistant descriptor-relative primitives rather than `check(path); syscall(path)`.
5. Define and document fallback guarantees on systems without `openat2`.
6. Make the API impossible/easy to use correctly: callers should supply a jail-relative path, not a pre-resolved absolute pathname.

## Regression tests
Test both sequential and concurrent attacks:
- replace an intermediate directory with a symlink;
- replace the final target between check and operation;
- swap source/destination parents during rename;
- use absolute/traversal/symlink aliases;
- assert an outside sentinel is never modified.

Race tests should execute many iterations and run on the supported Linux/filesystem configurations.

## Acceptance criteria
- Security-sensitive operations no longer rely on `realpath()` followed by an ordinary pathname syscall.
- Rename/unlink/rmdir guarantees are documented and tested.
- Linux/openat2 and fallback paths are covered.
- All higher-level filesystem handlers can use the same authoritative implementation.