### PR TITLE
Security: migrate native SFTP to the hardened filesystem boundary

### DIFF
--- a/docs/security-fix-guides/issue-16-pr-note.md
+++ b/docs/security-fix-guides/issue-16-pr-note.md
@@ -1,0 +1,3 @@
+# Example PR guide
+
+See issue #16 for the SFTP implementation and regression-test plan. This branch is a reference scaffold and is intentionally not a completed security fix.

--- a/docs/security-fix-guides/issue-16-sftp.md
+++ b/docs/security-fix-guides/issue-16-sftp.md
@@ -1,0 +1,36 @@
+# Issue #16 implementation guide — migrate native SFTP to the hardened filesystem boundary
+
+Reference implementation guide for #16.
+
+## Code surface
+
+`src/handlers/sftpSubsystem.ts` handles OPEN/READ/WRITE/FSTAT/REMOVE/RMDIR/MKDIR/READDIR/RENAME. It currently validates a path with its local `rooted()` logic and then performs ordinary pathname operations.
+
+## Target architecture
+
+Make SFTP consume the authoritative descriptor-relative filesystem layer from #15. A single connection/session should hold a trusted root directory descriptor; SFTP paths should remain relative to that root.
+
+For OPEN:
+- resolve the requested path relative to the root FD;
+- apply the requested access flags only after containment checks;
+- return a handle containing the opened FD and metadata needed for SFTP;
+- use `fstat`/descriptor operations instead of re-resolving the pathname.
+
+For REMOVE/RMDIR/MKDIR/RENAME/READDIR:
+- operate relative to trusted directory handles;
+- enforce both source and destination confinement for rename;
+- do not perform `check(path)` and then ordinary pathname syscalls.
+
+## Symlink policy
+
+Decide explicitly whether SFTP follows symlinks. The safest policy for a jailed management filesystem is to reject symlink traversal unless a concrete feature requires it. If symlinks are allowed, document exactly which operations may follow them and test them as a separate policy.
+
+## Tests
+
+Add protocol-level tests for symlinked ancestors, ancestor replacement during OPEN/WRITE/REMOVE/RENAME, FSTAT after path replacement, READDIR entries containing symlinks, source/destination races, and outside-root sentinel protection.
+
+Run race tests repeatedly. Verify the same behavior on supported Linux/openat2 and fallback platforms.
+
+## Acceptance criteria
+
+SFTP has no independent weaker path-security model. Every filesystem operation uses the same documented jail invariant as HTTP filesystem access, and open handles remain authoritative after the initial lookup.


### PR DESCRIPTION
## Summary
The native SFTP server has its own path-validation layer instead of using the daemon's hardened filesystem security primitives. This creates a second filesystem security boundary with weaker and inconsistent guarantees.

## Code paths
`src/handlers/sftpSubsystem.ts` handles filesystem requests including:
- OPEN / WRITE / READ
- FSTAT
- REMOVE / RMDIR
- MKDIR
- READDIR
- RENAME

The implementation validates with `rooted()` and then uses ordinary `openSync`, `statSync`, `unlinkSync`, `rmdirSync`, `mkdirSync`, and `renameSync` against the resulting pathname.

## Specific concerns
1. `rooted()` performs a separate containment check from the eventual syscall, leaving the same symlink/TOCTOU class as the HTTP filesystem routes.
2. OPEN followed by `statSync(path)` can report metadata for a different object than the FD that was opened. The open descriptor should be authoritative and metadata should come from `fstat`.
3. RENAME combines operations that need independent source/destination confinement and currently uses pathname-based operations.
4. READDIR and metadata operations construct child paths and perform new checks/opens rather than keeping a directory descriptor as the authority.
5. SFTP is network-facing, so this is not merely an internal helper that can safely rely on trusted callers.

## Proposed fix
- Refactor SFTP to consume the shared descriptor-relative filesystem boundary from issue #15.
- Represent open files/directories by descriptors and use `fstat`/descriptor-relative operations.
- Provide dedicated safe operations for remove, mkdir, rename, and directory enumeration.
- Delete the SFTP-local `rooted()` implementation once migration is complete.
- Define explicit symlink semantics; if symlinks are not required, reject them consistently.

## Tests
Add protocol-level regression tests for:
- symlinked ancestors;
- symlink replacement during OPEN/WRITE/REMOVE/RENAME;
- source/destination swap during RENAME;
- `FSTAT` after target replacement;
- READDIR entries whose names resolve outside the root;
- attempts to remove/rename outside-root sentinels.

Run race tests repeatedly rather than relying solely on deterministic sequential cases.

## Acceptance criteria
Every security-sensitive SFTP filesystem operation is mediated by the same jail invariant as HTTP filesystem operations. No operation relies on an earlier pathname validation as its final security boundary.