### PR TITLE
Security: restrict and canonicalize Docker host bind mounts

### DIFF
--- a/docs/security-fix-guides/issue-17-docker-mounts.md
+++ b/docs/security-fix-guides/issue-17-docker-mounts.md
@@ -1,0 +1,39 @@
+# Issue #17 implementation guide — restrict Docker host bind mounts
+
+Reference guide for #17. The goal is to turn host mounts into an explicit privileged capability rather than relying on a small lexical denylist.
+
+## Code surface
+
+- `src/handlers/dockerConfig.ts` validates mount configuration.
+- `src/schemas/container.ts` defines the incoming mount shape.
+- `src/handlers/docker.ts` maps the accepted source into Docker `HostConfig.Binds`.
+
+## Security model to establish
+
+Use an allowlist of daemon-owned host roots that may be exposed. Do not attempt to enumerate every forbidden host path.
+
+For every source path:
+
+1. Parse as a host filesystem path.
+2. Reject null bytes, malformed paths, and path aliases that leave the allowed root.
+3. Canonicalize existing ancestors before policy evaluation.
+4. Use path-component comparisons, not raw `startsWith` checks.
+5. Define a safe policy for nonexistent paths; avoid a validation/creation race where possible.
+6. Reject Unix sockets and host control-plane files unless a feature explicitly requires them.
+
+## Cases that must be decided and tested
+
+- `/etc`, `/home`, `/var/lib`, `/proc`, `/sys`, `/dev`;
+- `/run`, `/var/run`, and the Docker Unix socket;
+- symlink aliases into an allowed or forbidden tree;
+- relative paths and traversal attempts;
+- prefix-lookalikes such as `/procfoo`;
+- mount sources that disappear or are replaced after validation.
+
+## Defense in depth
+
+The API/UI should identify host mounts as privileged. Validation should be backed by the daemon's filesystem jail where appropriate, and Docker configuration should be inspected before container creation.
+
+## Acceptance criteria
+
+An untrusted container configuration cannot cause an arbitrary host path to be mounted. The policy is explicit, canonicalization-aware, documented, and covered by regression tests.

--- a/docs/security-fix-guides/issue-17-pr-note.md
+++ b/docs/security-fix-guides/issue-17-pr-note.md
@@ -1,0 +1,3 @@
+# Example PR guide
+
+See issue #17 for the Docker host-mount policy and tests. Reference scaffold only.


### PR DESCRIPTION
## Summary
Container configuration accepts host bind-mount sources and passes them into Docker `HostConfig.Binds`, but the current validation is primarily a lexical denylist. This is not a robust host filesystem policy.

## Code paths
- `src/handlers/dockerConfig.ts` validates mount configuration.
- `src/schemas/container.ts` defines the incoming mount shape.
- `src/handlers/docker.ts` translates validated configuration into Docker container creation options.

## Problems
- Raw string prefixes do not establish canonical filesystem identity.
- A symlink can make an apparently allowed source resolve somewhere sensitive.
- Prefix checks need path-component semantics; `/procfoo` should not be treated as `/proc`.
- `/run` and `/var/run` aliasing needs explicit policy.
- Sensitive paths such as `/etc`, `/home`, `/var/lib`, and Docker's Unix socket are not inherently prohibited by the current small denylist.
- Validation can occur before Docker creates the container, leaving a source-replacement window.

## Security impact
A compromised panel credential or other actor capable of changing container configuration could potentially turn a normal container-management operation into host filesystem exposure. Mounting a Docker control socket is particularly sensitive because it can become a path to host/container control rather than simple file disclosure.

## Proposed policy
Prefer an allowlist of host roots that the daemon explicitly intends to expose. For each source:
1. Normalize and canonicalize existing paths.
2. Validate path components, not string prefixes.
3. Define a policy for nonexistent sources.
4. Explicitly reject Unix sockets and host control-plane paths unless required.
5. Recheck or use an operation that eliminates the validation-to-mount race where possible.
6. Document bind mounts as a privileged feature and make the security boundary clear in the API/UI.

## Tests
Cover allowed roots, `/etc`, `/home`, `/var/lib`, `/proc`, `/sys`, `/dev`, `/run`, `/var/run`, `/var/run/docker.sock`, symlink aliases, `../` aliases, nonexistent sources, and prefix lookalikes such as `/procfoo`.

## Acceptance criteria
No untrusted container configuration can cause an arbitrary host path to be mounted. The policy is canonicalization-aware, explicit, documented, and regression-tested.