### PR TITLE
Security: eliminate DNS-rebinding gap in public URL fetching

### DIFF
--- a/docs/security-fix-guides/issue-18-ssrf.md
+++ b/docs/security-fix-guides/issue-18-ssrf.md
@@ -1,0 +1,31 @@
+# Issue #18 implementation guide — close the DNS rebinding window
+
+Reference guide for #18.
+
+## Current flow
+
+`src/router.ts` resolves a hostname and validates returned addresses before `src/handlers/fs.ts` later passes the original hostname to `fetch()`.
+
+That means the validated DNS result and the socket connection are separate events. Redirects are validated, but each hop can have the same problem.
+
+## Target design
+
+Bind SSRF policy to the actual connection:
+
+- use a custom resolver/agent that refuses disallowed destination addresses for every socket attempt; or
+- connect directly to the validated address while preserving Host/SNI/TLS semantics correctly; or
+- otherwise guarantee the resolver result cannot change between validation and connection.
+
+Keep redirects subject to the same policy. Do not weaken TLS certificate validation just to force an IP connection.
+
+## Edge cases
+
+Test IPv4, IPv6, IPv4-mapped IPv6, loopback, private/link-local ranges, unusual numeric IP forms, multiple DNS answers, connection retries, and redirect chains where DNS changes between hops. Audit whether HTTP proxy/environment settings can redirect the actual connection away from the validated destination.
+
+## Regression test
+
+A fake resolver should return a public IP during validation and a private IP for the subsequent connection. The request must fail before any connection to the private target occurs.
+
+## Acceptance criteria
+
+Every actual connection attempt is covered by the SSRF address policy. Passing hostname validation alone can never authorize a connection to a newly resolved disallowed address.


### PR DESCRIPTION
## Summary
The daemon has an SSRF validator that resolves a hostname and rejects private/loopback/link-local addresses, but the later HTTP request passes the original hostname to ordinary `fetch()`. Validation and connection therefore are not cryptographically/operationally bound to the same DNS result.

## Code paths
- `src/router.ts`: public URL validation and DNS/IP classification.
- `src/handlers/fs.ts`: public URL fetching.
- `src/routes/filesystem.ts`: download/fetch-related route handling.

## Failure mode
Conceptually the flow is:

`hostname -> DNS lookup -> validate IP -> later fetch(hostname) -> DNS lookup -> connect`

A malicious or compromised DNS service can answer with a public address during validation and a private address during the later connection. Redirect validation reduces the attack surface but does not remove the validation-to-connection gap.

The source comments currently imply DNS rebinding is defeated; that claim should not remain unless the actual socket connection is constrained by the validated result.

## Required design
Choose one authoritative approach:
- connect directly to the validated address while preserving the original Host/SNI semantics safely; or
- use a custom resolver/HTTP agent that applies the SSRF policy to every actual socket connection; or
- otherwise guarantee that DNS cannot change between validation and connect.

The implementation must preserve correct IPv4/IPv6 hostname behavior and TLS certificate validation.

## Additional cases to audit
- IPv4-mapped IPv6 addresses;
- IPv6 loopback/link-local/private ranges;
- redirects between different hostnames;
- redirects where DNS changes between hops;
- unusual numeric IP forms;
- DNS responses containing multiple addresses;
- connection retries that perform fresh DNS resolution;
- proxy/environment configuration that changes where `fetch()` connects.

## Tests
Build a deterministic fake resolver/agent test where validation receives a public IP but the subsequent connection is attempted against a private IP. Add redirect and IPv6 variants.

## Acceptance criteria
A URL cannot pass validation and subsequently cause the HTTP client to connect to a disallowed address solely because DNS changed. The invariant must apply to every actual connection attempt, not just the initial validation lookup.