### PR TITLE
Security: route backup writes through the authoritative backup jail

### DIFF
--- a/docs/security-fix-guides/issue-19-backups.md
+++ b/docs/security-fix-guides/issue-19-backups.md
@@ -1,0 +1,27 @@
+# Issue #19 implementation guide — centralize backup storage security
+
+Reference guide for #19.
+
+## Problem
+
+`src/routes/backups.ts` does not use one backup filesystem abstraction for all operations. Create/upload construct paths directly from `backupsRoot`, while restore/download/delete use centralized helpers.
+
+This split means a future fix can harden one route while leaving another on a weaker path model.
+
+## Target design
+
+Introduce a backup storage service responsible for root discovery, container directory resolution, filename validation, temporary uploads, atomic promotion, reads, and deletion. Route handlers should deal only in logical IDs/names and never make security decisions with `join(backupsRoot, ...)` themselves.
+
+Final operations should use the race-safe primitives from #15. Uploads should land in controlled temporary files and be promoted only after validation/complete write.
+
+## Concurrency
+
+Define behavior for two uploads to the same backup, upload vs delete, restore vs upload, and cleanup after interrupted uploads. Do not allow a stale pathname to be reused after another actor changes the directory.
+
+## Tests
+
+Cover symlinked `backups/<id>`, concurrent replacement during create/upload, traversal-like IDs and names, existing destination replacement, partial upload cleanup, and concurrent operations. Use an outside sentinel to prove containment.
+
+## Acceptance criteria
+
+Create, upload, restore, download, and delete share the same backup security boundary and no route directly reconstructs security-sensitive backup paths.


### PR DESCRIPTION
## Summary
Backup operations do not consistently use the centralized backup path security layer. Create/upload construct backup paths directly, while other operations use `resolveBackupPath()` / `resolveBackupsRoot()`.

## Code paths
- `src/routes/backups.ts` create flow around the backup directory/file construction.
- `src/routes/backups.ts` upload flow around multipart/file upload handling.
- `src/security/pathJail.ts` backup-root resolution helpers.

## Problem
The security policy is split across routes. A future change can fix restore/download/delete while accidentally leaving create/upload exposed to the weaker path construction model.

The problem is especially relevant because a `backups/<container-id>` directory can be replaced by a symlink or other filesystem object between path validation and the eventual write. The centralized jail itself also has the race limitations tracked in #15.

## Proposed fix
Create a dedicated backup storage service/API responsible for:
- resolving the backup root;
- resolving a container's backup directory;
- validating backup filenames;
- creating backup files;
- accepting uploads into controlled temporary files;
- atomically promoting completed files;
- deleting and reading backups.

Routes should never construct backup filesystem paths themselves.

All final filesystem operations should use the race-safe primitives from #15.

## Tests
Add coverage for:
- symlinked `backups/<id>` directories;
- symlink replacement while creating a backup;
- symlink replacement during upload;
- traversal and separator edge cases in IDs/filenames;
- existing destination replacement;
- upload failure cleanup;
- concurrent operations against the same backup ID.

Use an outside sentinel to prove that no operation can write/delete/read outside the configured backup root.

## Acceptance criteria
Create, upload, restore, download, and delete share one backup security boundary. There are no route-level `join(backupsRoot, ...)` security decisions left outside the storage abstraction.