### PR TITLE
Security: bind download authorization and config writes to the secure filesystem boundary

### DIFF
--- a/docs/security-fix-guides/issue-20-file-authorization.md
+++ b/docs/security-fix-guides/issue-20-file-authorization.md
@@ -1,0 +1,34 @@
+# Issue #20 implementation guide — bind file authorization to the secure object
+
+Reference guide for #20.
+
+## Download tokens
+
+`src/routes/filesystem.ts` stores an absolute `filePath` inside the token. Consumption later checks the path and calls `Bun.file(path)`. Backup downloads have similar semantics.
+
+The token can therefore be cryptographically valid while the filesystem object behind its pathname has changed.
+
+### Target design
+
+At token consumption:
+- resolve the logical path relative to the intended jail;
+- securely open the file under the jail;
+- verify type/size against policy using the open descriptor;
+- stream/read from that descriptor or an equivalent stable file object;
+- preserve token expiry and single-use behavior.
+
+Do not use a prior `existsSync()` or `realpath()` result as the final authorization check.
+
+## Config-file writes
+
+`src/handlers/configFiles.ts` performs `resolve`/prefix checks and then uses ordinary read/write calls. Migrate both read and write to the shared secure filesystem API.
+
+Define explicit behavior for symlinks, replacement of existing files, file-vs-directory confusion, and concurrent changes.
+
+## Tests
+
+Mint a token, replace the target/ancestor, then consume it. Replace config targets with symlinks and race the write with directory replacement. Verify outside sentinels never change.
+
+## Acceptance criteria
+
+Authorization is bound to the intended jailed object at the moment of use. No download or config write relies on a previously validated mutable pathname as its final security boundary.


### PR DESCRIPTION
## Summary
Two independent code paths authorize or validate a filesystem pathname and then perform a later operation against that mutable pathname: download tokens and config-file mutation.

## Download tokens
`src/routes/filesystem.ts` stores an absolute `filePath` in a single-use token. Consumption later checks the path and creates a `Bun.file()` from it. Backup download handling has a similar pattern.

The token can be cryptographically valid and single-use while the underlying resource has changed since issuance. Authorization should describe the intended filesystem object, not merely a pathname that can later resolve differently.

### Proposed fix
- At consumption, resolve/open the resource through the hardened filesystem boundary.
- Prefer an open descriptor or stable file identity semantics where supported.
- Preserve existing expiry and single-use guarantees.
- Ensure backup downloads follow the same implementation.

## Config-file writes
`src/handlers/configFiles.ts` derives a target under the volume root, performs lexical containment/existence checks, then reads/writes the pathname with ordinary file APIs.

This bypasses the authoritative filesystem jail and leaves the final write dependent on the pathname remaining unchanged.

### Proposed fix
- Route config-file reads/writes through the shared secure filesystem API from #15.
- Remove route-local `resolve`/prefix checks as the final security boundary.
- Define explicit behavior for symlinks and replacement of existing files.

## Regression tests
- issue a token, change the target, then consume it;
- replace targets/ancestors with symlinks before file access;
- manipulate the volume tree during config read/write;
- verify files outside the intended root are never accessed or modified;
- retain tests for token expiry and single-use semantics.

## Acceptance criteria
Neither feature relies on a previously validated mutable pathname as its final security boundary. All file access is performed through the same documented jail invariant used by the rest of the daemon.