### PR TITLE
Security: make chunked upload finalization use race-safe jailed rename

### DIFF
--- a/docs/security-fix-guides/issue-21-chunked-uploads.md
+++ b/docs/security-fix-guides/issue-21-chunked-uploads.md
@@ -1,0 +1,20 @@
+# Issue #21 implementation guide — race-safe chunk upload finalization
+
+`src/handlers/fsArchive.ts` validates a destination, writes a temporary pathname, then promotes it with ordinary `rename`. Atomic rename does not by itself preserve jail confinement.
+
+## Target behavior
+
+- Create the temporary file inside the destination directory using a secure temp-file primitive.
+- Keep the destination directory anchored by the filesystem jail from #15.
+- Perform promotion through the race-safe rename API.
+- Define overwrite semantics explicitly.
+- Ensure interrupted uploads cannot leave attacker-controlled temporary paths that later get reused.
+- Prefer CSPRNG/dedicated temporary names over `Math.random()`.
+
+## Tests
+
+Race ancestor/destination replacement during finalization, symlink both target and parent, concurrent uploads to the same filename, existing-target replacement, and interrupted cleanup. Verify an outside sentinel remains unchanged.
+
+## Acceptance
+
+Chunk finalization has the same confinement guarantee as direct writes and cannot be redirected outside the volume between validation, temporary-file creation, and promotion.


### PR DESCRIPTION
## Summary
Chunked upload finalization validates the destination, writes a temporary file by pathname, and then performs an ordinary rename. POSIX rename atomicity does not itself guarantee that the destination remains inside the intended jail.

## Code path
`src/handlers/fsArchive.ts` handles chunk accumulation and finalization. The finalization path computes the target, writes temporary data, and promotes it with a pathname-based rename.

## Risks
- The destination or an ancestor can change after validation.
- The temporary file is not consistently tied to a descriptor-relative jail.
- Security depends on the same pathname remaining trustworthy across multiple operations.
- `Math.random()` is used for temporary naming; this is not the primary security issue, but a dedicated temporary-file primitive would reduce collision and cleanup concerns.

## Proposed fix
1. Create the temporary file inside the target directory using a secure temporary-file primitive.
2. Keep the target directory anchored by a trusted directory FD.
3. Perform final promotion with the race-safe rename primitive from #15.
4. Ensure failed uploads clean up temporary files without crossing the jail.
5. Define behavior when the destination already exists.

## Tests
- concurrent replacement of destination/ancestor during finalization;
- symlinked destination and parent directories;
- existing destination replacement;
- interrupted upload cleanup;
- repeated concurrent uploads to the same path;
- outside sentinel verification.

## Acceptance criteria
Chunked upload finalization has the same confinement guarantees as direct file writes and cannot be redirected outside the volume by filesystem changes between validation and rename.