### PR TITLE
Security: unify HTTP/WebSocket proxy trust and effective-client-IP resolution

### DIFF
--- a/docs/security-fix-guides/issue-22-pr-note.md
+++ b/docs/security-fix-guides/issue-22-pr-note.md
@@ -1,0 +1,3 @@
+# Example PR guide
+
+See issue #22 for the proxy trust implementation and test matrix. Reference scaffold only.

--- a/docs/security-fix-guides/issue-22-proxy-trust.md
+++ b/docs/security-fix-guides/issue-22-proxy-trust.md
@@ -1,0 +1,17 @@
+# Issue #22 implementation guide — unify proxy trust and client IP resolution
+
+`src/server.ts` and `src/router.ts` independently derive the effective client IP. Both have a legacy mode where a private peer can justify trusting `X-Forwarded-For` when explicit trusted proxies are not configured.
+
+## Target design
+
+Create one resolver taking `(peerIp, forwardedChain, trustedProxyPolicy)` and use it for HTTP and WebSocket. Trust forwarding headers only when the immediate peer is explicitly trusted; parse multi-hop chains from the trusted edge inward; reject malformed values; define duplicate-header behavior; and fail closed/disable forwarding trust when proxy configuration is incomplete.
+
+All rate limiting, allowlists, logging, and WebSocket policy should use the same resolved identity.
+
+## Tests
+
+Cover trusted/untrusted public and private peers, one/multiple hops, duplicate/malformed headers, missing headers, `BEHIND_PROXY` with no trusted list, IPv4/IPv6, and identical HTTP/WebSocket metadata.
+
+## Acceptance
+
+There is one documented implementation and an untrusted peer cannot spoof the identity consumed by security controls.


### PR DESCRIPTION
## Summary
HTTP and WebSocket request handling each implement proxy trust/effective-client-IP logic. This is security-sensitive because the resulting IP is used by rate limiting and access-control decisions.

## Code paths
- `src/server.ts`: proxy configuration and connection metadata handling.
- `src/router.ts`: request-side effective IP calculation.
- WebSocket upgrade handling has a separate implementation.

## Problems
1. The same policy is duplicated, so HTTP and WebSocket behavior can drift.
2. With `BEHIND_PROXY=true`, a private immediate peer can be treated as sufficient reason to trust `X-Forwarded-For` when explicit trusted-proxy configuration is absent.
3. Multi-hop forwarding semantics need to be explicit; simply taking the first list element is not necessarily the correct trusted-client calculation.
4. Missing/invalid proxy configuration should not silently broaden trust.

## Proposed design
Create a single `resolveEffectiveClientIp(peerIp, forwardedHeaders, trustedProxies)` implementation and use it everywhere.

Recommended policy:
- Trust forwarding headers only when the immediate peer is explicitly trusted.
- Parse the complete forwarding chain according to the configured trusted-proxy topology.
- Define behavior for malformed addresses and duplicate headers.
- Fail closed or disable forwarded-header trust when proxy configuration is incomplete.
- Keep rate limiting, audit logs, allowlists, and WebSocket authorization on the same identity source.

## Tests
Cover trusted/untrusted proxies, public/private peers, one and multiple forwarding hops, malformed values, duplicate headers, missing headers, and identical HTTP/WebSocket metadata.

## Acceptance criteria
There is one documented proxy trust policy, one implementation, and identical effective-client-IP results across HTTP and WebSocket paths. An untrusted peer cannot spoof the identity used by security controls.