### PR TITLE
Security: normalize archive extraction defenses for backup restore

### DIFF
--- a/docs/security-fix-guides/issue-23-archive-restore.md
+++ b/docs/security-fix-guides/issue-23-archive-restore.md
@@ -1,0 +1,17 @@
+# Issue #23 implementation guide — unify archive extraction security
+
+Backup restore and generic archive extraction currently follow different security models. `src/handlers/fsArchive.ts` performs explicit member validation and post-extraction containment checks, while `src/routes/backups.ts` uses a separate tar extraction path.
+
+## Target design
+
+Use one archive validation/extraction service for every untrusted archive. Validate normalized member paths before extraction; reject absolute/traversal names; define explicit symlink/hardlink policy; extract only into an isolated staging directory; verify the complete extracted tree remains inside staging; and only then promote into the live volume.
+
+Promotion must use the hardened filesystem operations from #15.
+
+## Fixtures
+
+Include `../` entries, absolute names, symlinks outside staging, nested symlinks, hardlinks, duplicate/conflicting entries, normalization tricks, and file/directory collisions. Rejected archives must leave the live volume unchanged and clean staging state.
+
+## Acceptance
+
+Backup restore and generic extraction share one explicit security policy. No archive entry can escape staging, and untrusted partial extraction never reaches a live volume.


### PR DESCRIPTION
## Summary
The generic archive extraction path and backup restore use different security models. Generic extraction performs explicit member validation and post-extraction containment checks, while backup restore delegates directly to tar extraction into a staging directory before promotion.

## Code paths
- `src/handlers/fsArchive.ts`: generic archive extraction and archive-member checks.
- `src/routes/backups.ts`: backup restore staging/extraction/promotion.

## Why this matters
Backups can be uploaded/imported and should be treated as untrusted input unless provenance is cryptographically guaranteed. Tar archives can contain traversal names, absolute paths, symlinks, hardlinks, and metadata that behave differently across extraction implementations.

Even if the underlying `tar` library currently has protections, the daemon should own the security invariant rather than depending on implicit library behavior. Two extraction paths also create a future regression risk when one is hardened and the other is not.

## Proposed design
- Reuse one archive validation/extraction policy.
- Validate every member before extraction where practical.
- Reject absolute paths and normalized traversal.
- Define explicit policy for symlinks and hardlinks; safest default is reject unless a concrete backup requirement exists.
- Extract only into an isolated staging directory.
- Verify the resulting tree remains within staging after extraction.
- Do not promote until validation succeeds.
- Make promotion itself use the hardened filesystem operations from #15.

## Test fixtures
Include malicious archives containing traversal paths, absolute paths, symlinks to outside locations, nested symlinks, hardlinks, duplicate names, unusual normalization, and conflicting file/directory entries.

Verify failed extraction leaves the live volume untouched and cleans staging data.

## Acceptance criteria
Backup restore and generic archive extraction share the same explicit archive security policy. No archive entry can cause writes outside staging, and no partially extracted untrusted tree can reach a live volume.