### PR TITLE
Cleanup: consolidate filesystem security APIs and remove stale exports

### DIFF
--- a/docs/security-fix-guides/issue-24-security-api-cleanup.md
+++ b/docs/security-fix-guides/issue-24-security-api-cleanup.md
@@ -1,0 +1,15 @@
+# Issue #24 implementation guide — consolidate filesystem security APIs
+
+The repository has overlapping security helpers in `src/security/pathJail.ts` and `src/security/secureOpen.ts`, plus route-local path construction and validation.
+
+## Target refactor
+
+Create one authoritative filesystem-security facade with documented operations for open/read/write/create/remove/rmdir/rename/mkdir/enumerate. Keep pure input parsing separate from security-sensitive filesystem operations.
+
+Callers should provide jail-relative logical paths. Avoid APIs that return a pre-resolved absolute path and leave callers responsible for preserving its security properties.
+
+Migrate SFTP, backups, config writes, chunked uploads, and Docker initialization to the same facade. After migration, use type-aware/project-wide analysis to confirm stale exports such as `secureReadFileSync`, `secureWriteFileSync`, `hasOpenat2`, `validatePort`, `requireContainerId`, `backupsPathFor`, `getServerState`, `getAllServerStates`, `flushStatsPersistence`, `clearNonceCache`, and `clearRateLimit` before deletion; preserve intentional public/test compatibility exports.
+
+## Acceptance
+
+There is one obvious secure API for filesystem operations, the guarantees of each primitive are documented, and route code cannot accidentally bypass the central boundary by reconstructing paths.


### PR DESCRIPTION
## Summary
The repository has overlapping filesystem-security abstractions and multiple independent path-construction policies. This makes security correctness dependent on which helper a caller happens to choose.

## Observed duplication
`src/security/pathJail.ts` and `src/security/secureOpen.ts` expose overlapping operations such as secure read/write helpers, synchronous variants, and `hasOpenat2()` capability detection.

Other modules independently construct volume, backup, and config paths using `join`, `resolve`, `startsWith`, `realpath`, or local validation helpers.

A static usage pass also found apparent stale-export candidates including `validatePort`, `requireContainerId`, `backupsPathFor`, `getServerState`, `getAllServerStates`, `flushStatsPersistence`, `clearNonceCache`, `clearRateLimit`, `secureReadFileSync`, `secureWriteFileSync`, and `hasOpenat2`. These need type-aware confirmation before removal.

## Why cleanup is security-relevant
Having several APIs named as if they are equally secure is dangerous when their guarantees differ. The audit already found real call sites that bypass stronger helpers. Centralizing the boundary makes insecure usage harder to introduce during future changes.

## Proposed refactor
1. Define a single filesystem-security facade.
2. Separate pure path parsing from security-sensitive filesystem operations.
3. Document guarantees for open/read/write/create/remove/rename/mkdir/enumerate.
4. Make callers use jail-relative paths and operation-specific APIs rather than pre-resolved absolute paths.
5. Centralize volume/backup/storage root derivation.
6. Migrate SFTP, backup, config, upload, and Docker initialization callers.
7. Use project-wide/type-aware symbol analysis before deleting exports.
8. Remove compatibility wrappers only after all imports/tests are migrated.

## Deliverables
- one documented security API;
- no route-local filesystem security checks that duplicate the central policy;
- dead-export report with intentional public/test exports identified;
- updated tests and imports;
- documentation of platform-specific behavior.

## Acceptance criteria
A new filesystem feature has one obvious secure API to use. There are no materially different 'secure' helpers with undocumented guarantees, and path construction cannot silently bypass the central filesystem boundary.