### PR TITLE
Security: harden Docker volume initialization against symlink/path replacement

### DIFF
--- a/docs/security-fix-guides/issue-25-docker-volumes.md
+++ b/docs/security-fix-guides/issue-25-docker-volumes.md
@@ -1,0 +1,20 @@
+# Issue #25 implementation guide — harden Docker volume initialization
+
+`src/handlers/docker.ts` constructs volume paths and writes initialization/configuration files using ordinary filesystem APIs. The volume directory is not consistently anchored to a trusted directory object.
+
+## Target design
+
+- Resolve the volume root through the authoritative filesystem security API from #15/#24.
+- Treat the configured volumes root as an anchored directory, not a string prefix.
+- Validate container/volume identifiers at the API boundary but do not use identifier validation as the filesystem security boundary.
+- Securely create/write `eula.txt`, `.airlinkd/init.sh`, and other initialization files relative to the trusted volume directory.
+- Define behavior for an existing path that is a symlink, regular file, unexpected directory, or replacement during initialization.
+- Ensure error cleanup cannot cross the volume root.
+
+## Tests
+
+Cover new/existing volumes, symlinked volume directories, replaced ancestors, file-vs-directory mismatches, concurrent replacement while initialization files are created, and cleanup after partial initialization. Use an outside sentinel to prove confinement.
+
+## Acceptance
+
+Volume initialization cannot write outside the configured volume root, even under concurrent filesystem manipulation, and uses the same secure primitives as other daemon-managed storage.


### PR DESCRIPTION
## Summary
Docker volume initialization constructs volume paths and writes initialization files with ordinary filesystem APIs. The volume root is not consistently treated as a securely opened, jail-anchored directory.

## Code paths
`src/handlers/docker.ts` contains volume setup and initialization writes, including files such as `eula.txt` and daemon initialization content.

## Risk
The code can establish a path under the configured volumes root and then perform later filesystem operations against that pathname. If an existing volume directory or ancestor changes between those steps, initialization may operate on a different filesystem object than intended.

This is the same class of validation/use problem tracked in #15, but Docker initialization deserves its own migration because it can run during container lifecycle operations and is easy to overlook when hardening HTTP filesystem endpoints.

## Proposed fix
- Resolve volume roots through one authoritative volume-storage API.
- Treat the volumes root as an anchored directory rather than a string prefix.
- Use secure descriptor-relative creation/write operations for initialization files.
- Define behavior for existing volumes and unexpected filesystem objects.
- Ensure container/volume identifiers are validated at the API boundary but do not rely on identifier validation as filesystem confinement.
- Coordinate implementation with #15 so this code does not retain a second weaker filesystem model.

## Tests
Cover new and existing volumes, symlinked volume directories, replaced ancestors, unexpected file-vs-directory types, concurrent replacement during creation of `eula.txt` and initialization files, and failure cleanup.

Use an outside sentinel and verify it remains unchanged under adversarial filesystem manipulation.

## Acceptance criteria
Volume initialization cannot write outside the configured volume root. Existing-volume handling is explicit, race behavior is documented, and initialization uses the same hardened filesystem primitives as the rest of the daemon.