### PR TITLE
Security: enforce SFTP filesystem-boundary regression contract

### DIFF
--- a/tests/security/sftpBoundary.test.ts
+++ b/tests/security/sftpBoundary.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../src/handlers/sftpSubsystem.ts', import.meta.url), 'utf8');
+
+describe('SFTP filesystem boundary contract', () => {
+  test('does not reintroduce pathname-based destructive operations', () => {
+    expect(source).not.toMatch(/unlinkSync\(/);
+    expect(source).not.toMatch(/rmdirSync\(/);
+    expect(source).not.toMatch(/renameSync\(/);
+  });
+
+  test('does not derive security-sensitive child paths solely with join()', () => {
+    expect(source).not.toMatch(/statSync\(join\(/);
+  });
+});


### PR DESCRIPTION
Closes #16

Test-first implementation PR. Adds executable guards that fail while the native SFTP subsystem still performs pathname-based destructive operations outside the hardened filesystem boundary.

The intended follow-up is to migrate SFTP operations to the descriptor-relative primitives from #15, then make these tests pass.