### PR TITLE
Security: add SSRF DNS-rebinding regression contract

### DIFF
--- a/tests/security/ssrfConnectionContract.test.ts
+++ b/tests/security/ssrfConnectionContract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const router = readFileSync(new URL('../../src/router.ts', import.meta.url), 'utf8');
+const fsHandler = readFileSync(new URL('../../src/handlers/fs.ts', import.meta.url), 'utf8');
+
+describe('SSRF connection contract', () => {
+  test('must not validate one DNS result and then blindly fetch the hostname', () => {
+    expect(router).not.toContain('This defeats DNS rebinding');
+    expect(fsHandler).not.toMatch(/fetch\([^\n]*url[^\n]*\)/);
+  });
+});


### PR DESCRIPTION
Closes #18

Adds an executable regression guard around the public-URL fetch path. It documents the key invariant: SSRF validation must govern the address used by the actual connection, not just an earlier DNS lookup.

The test is intentionally red against the current implementation and should turn green once the fetcher is bound to a policy-enforcing resolver/connection.