### PR TITLE
Security: add download/config path replacement regression guards

### DIFF
--- a/tests/security/downloadConfigBoundary.test.ts
+++ b/tests/security/downloadConfigBoundary.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const filesystemRoutes = readFileSync(new URL('../../src/routes/filesystem.ts', import.meta.url), 'utf8');
+const configFiles = readFileSync(new URL('../../src/handlers/configFiles.ts', import.meta.url), 'utf8');
+
+describe('download/config filesystem boundary contract', () => {
+  test('download token consumption must not trust a mutable pathname directly', () => {
+    expect(filesystemRoutes).not.toMatch(/Bun\.file\(entry\.filePath\)/);
+  });
+
+  test('config writes must not use resolve+startsWith as the final security check', () => {
+    expect(configFiles).not.toMatch(/startsWith\([^\n]+volumeRoot/);
+    expect(configFiles).not.toMatch(/Bun\.write\(target/);
+  });
+});


### PR DESCRIPTION
Closes #20

Adds executable guards for the two mutable-path authorization flows identified in the audit: download-token consumption and config-file writes. The tests encode the requirement that the final file operation must use the hardened filesystem boundary rather than a previously validated pathname.