### PR TITLE
Security: add chunked-upload rename regression guard

### DIFF
--- a/tests/security/chunkedUploadBoundary.test.ts
+++ b/tests/security/chunkedUploadBoundary.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../src/handlers/fsArchive.ts', import.meta.url), 'utf8');
+
+describe('chunked upload finalization contract', () => {
+  test('must use the centralized jailed rename primitive', () => {
+    expect(source).toContain('jailRename');
+    expect(source).not.toMatch(/await rename\(tmpPath, filePath\)/);
+  });
+
+  test('must not use pathname-only temporary file promotion', () => {
+    expect(source).not.toMatch(/const tmpPath = `\$\{filePath\}\.part-/);
+  });
+});


### PR DESCRIPTION
Closes #21

Adds an executable contract requiring chunked-upload finalization to use the centralized jailed rename path instead of directly renaming a mutable pathname. This is the test-first half of the fix; the implementation should migrate final promotion to the race-safe primitive from #15.