### PR TITLE
Security: add archive-restore containment regression contract

### DIFF
--- a/tests/security/archiveRestoreContract.test.ts
+++ b/tests/security/archiveRestoreContract.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const backups = readFileSync(new URL('../../src/routes/backups.ts', import.meta.url), 'utf8');
+const archive = readFileSync(new URL('../../src/handlers/fsArchive.ts', import.meta.url), 'utf8');
+
+describe('archive restore security contract', () => {
+  test('backup restore must reuse the explicit archive validation path', () => {
+    expect(backups).toContain('assertSafeArchiveEntry');
+  });
+
+  test('generic archive handling must retain post-extraction containment checks', () => {
+    expect(archive).toContain('realpathSync');
+  });
+});


### PR DESCRIPTION
Closes #23

Adds executable guards requiring backup restore to use the daemon's explicit archive-safety policy and retain post-extraction containment verification. This makes the difference between generic archive extraction and backup restore visible to CI.