### PR TITLE
Security: add Docker volume initialization boundary guard

### DIFF
--- a/tests/security/dockerVolumeInitBoundary.test.ts
+++ b/tests/security/dockerVolumeInitBoundary.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../src/handlers/docker.ts', import.meta.url), 'utf8');
+
+describe('Docker volume initialization boundary', () => {
+  test('initialization writes must use the hardened filesystem layer', () => {
+    expect(source).toContain('secureWriteFile');
+    expect(source).not.toMatch(/writeFileSync\(eulaPath/);
+    expect(source).not.toMatch(/writeFileSync\(join\(airlinkdDir/);
+  });
+});


### PR DESCRIPTION
Closes #25

Adds an executable regression guard requiring volume initialization files to use the hardened filesystem write layer. The current code is expected to fail this contract until initialization is migrated from direct pathname writes.